### PR TITLE
everted to returning adjacency list with numpy arrays instead of python lists

### DIFF
--- a/box-intersect-lib-py/Cargo.lock
+++ b/box-intersect-lib-py/Cargo.lock
@@ -10,11 +10,11 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "box-intersect-lib"
-version = "0.8.4"
+version = "0.8.5"
 
 [[package]]
 name = "box-intersect-lib-py"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "box-intersect-lib",
  "numpy",

--- a/box-intersect-lib-py/Cargo.toml
+++ b/box-intersect-lib-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "box-intersect-lib-py"
-version = "0.8.4"
+version = "0.8.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -9,6 +9,6 @@ name = "box_intersect_lib_py"
 crate-type = ["cdylib"]
 
 [dependencies]
-box-intersect-lib = { path = "../box-intersect-lib", version="0.8.4" }
+box-intersect-lib = { path = "../box-intersect-lib", version="0.8.5" }
 pyo3 = { version = "0.26.0", features = ["extension-module"] }
 numpy = "0.26.0"

--- a/box-intersect-lib-py/src/lib.rs
+++ b/box-intersect-lib-py/src/lib.rs
@@ -77,10 +77,10 @@ fn np_arr_to_box(array: &PyReadonlyArray1<i32>) -> PyResult<Box> {
     Ok(box_)
 }
 
-fn adj_list_to_py_list(py: Python<'_>, adj_list: Vec<Vec<u32>>) -> PyResult<Bound<'_, PyList>> {
-    let mut list:Vec<Bound<'_, PyList>> = Vec::new();
+fn adj_list_to_py_list(py: Python<'_>, adj_list: Vec<Vec<u32>>) -> PyResult<pyo3::Bound<'_, PyList>> {
+    let mut list:Vec<BoundU32Array1<'_>> = Vec::new();
     for l in adj_list {
-        let pyl = PyList::new(py, l.clone())?;
+        let pyl = PyArray::from_vec(py, l.clone());
         list.push(pyl);
     }
     PyList::new(

--- a/box-intersect-lib/Cargo.toml
+++ b/box-intersect-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "box-intersect-lib"
-version = "0.8.4"
+version = "0.8.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Bugfix for regression from version 0.8.4 where adjacency lists were returned from lists instead of arrays
Also bumps to version 0.8.5